### PR TITLE
ツイートapiを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 __pycache__
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 __pycache__
 .env
+.idea
+venv/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv
 pytest
 requests
 python-dateutil
+requests-oauthlib

--- a/backend/twitter_tool/db_handler.py
+++ b/backend/twitter_tool/db_handler.py
@@ -1,0 +1,18 @@
+from dotenv import load_dotenv
+import os
+
+def DbHandler():
+    def __init__(self):
+        load_dotenv()
+    
+    @staticmethod
+    def get_keys(self, twitter_tool_user_id, twitter_username):
+        consumer_key = os.getenv("CONSUMER_KEY")
+        consumer_secret = os.getenv("CONSUMER_SECRET")
+        
+        # TODO: twitter_tool_user_id, twitter_usernameをキーにして、
+        # DBからaccess_tokenとaccess_token_secretを取得する
+        access_token = os.getenv("ACCESS_TOKEN")
+        access_token_secret = os.getenv("ACCESS_TOKEN_SECRET")
+        
+        return consumer_key, consumer_secret, access_token, access_token_secret

--- a/backend/twitter_tool/db_handler.py
+++ b/backend/twitter_tool/db_handler.py
@@ -1,18 +1,21 @@
 from dotenv import load_dotenv
 import os
 
-def DbHandler():
+
+class DbHandler():
     def __init__(self):
         load_dotenv()
     
-    @staticmethod
     def get_keys(self, twitter_tool_user_id, twitter_username):
         consumer_key = os.getenv("CONSUMER_KEY")
         consumer_secret = os.getenv("CONSUMER_SECRET")
-        
-        # TODO: twitter_tool_user_id, twitter_usernameをキーにして、
-        # DBからaccess_tokenとaccess_token_secretを取得する
-        access_token = os.getenv("ACCESS_TOKEN")
-        access_token_secret = os.getenv("ACCESS_TOKEN_SECRET")
+
+        # TODO:twitter_tool_user_id, twitter_usernameをキーにして、DBからaccess_tokenとaccess_token_secretを取得する
+        if twitter_tool_user_id == "1" and twitter_username == "devjima":
+            access_token = os.getenv("ACCESS_TOKEN")
+            access_token_secret = os.getenv("ACCESS_TOKEN_SECRET")
+        else:
+            access_token = ""
+            access_token_secret = ""
         
         return consumer_key, consumer_secret, access_token, access_token_secret

--- a/backend/twitter_tool/models.py
+++ b/backend/twitter_tool/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class User(models.Model):
+    username = models.CharField(max_length=16)
+    name = models.CharField()
+    status = models.CharField()

--- a/backend/twitter_tool/twitter_api_v2_handler.py
+++ b/backend/twitter_tool/twitter_api_v2_handler.py
@@ -1,0 +1,18 @@
+from requests_oauthlib import OAuth1Session
+
+class TwitterApiV2Hander:
+    def __init__(self, consumer_key, consumer_secret, access_token, access_token_secret):
+        self.oauth = OAuth1Session(
+            consumer_key,
+            client_secret=consumer_secret,
+            resource_owner_key=access_token,
+            resource_owner_secret=access_token_secret,
+        )
+
+    def create_tweet(self, text):
+        payload = { "text": text }
+        response = self.oauth.post(
+            "https://api.twitter.com/2/tweets",
+            json=payload,
+        )
+        return response.status_code

--- a/backend/twitter_tool/twitter_api_v2_handler.py
+++ b/backend/twitter_tool/twitter_api_v2_handler.py
@@ -1,6 +1,7 @@
 from requests_oauthlib import OAuth1Session
 
-class TwitterApiV2Hander:
+
+class TwitterApiV2Handler:
     def __init__(self, consumer_key, consumer_secret, access_token, access_token_secret):
         self.oauth = OAuth1Session(
             consumer_key,
@@ -15,4 +16,4 @@ class TwitterApiV2Hander:
             "https://api.twitter.com/2/tweets",
             json=payload,
         )
-        return response.status_code
+        return response

--- a/backend/twitter_tool/urls.py
+++ b/backend/twitter_tool/urls.py
@@ -4,5 +4,6 @@ from . import views
 
 urlpatterns = [
     path('ping', views.ping, name="sping"),
-    path('echo_post_json', views.echo_post_json, name="echo_post_json")
+    path('echo_post_json', views.echo_post_json, name="echo_post_json"),
+    path('tweets/create', views.create_tweet, name="create_tweet")
 ]

--- a/backend/twitter_tool/views.py
+++ b/backend/twitter_tool/views.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
-from twitter_api_v2_handler import TwitterApiV2Hander
-from db_handler import DbHandler
+from twitter_tool.twitter_api_v2_handler import TwitterApiV2Hander
+from twitter_tool.db_handler import DbHandler
 import json
 
 @api_view(["GET"])

--- a/backend/twitter_tool/views.py
+++ b/backend/twitter_tool/views.py
@@ -1,5 +1,7 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
+from twitter_api_v2_handler import TwitterApiV2Hander
+from db_handler import DbHandler
 import json
 
 @api_view(["GET"])
@@ -18,3 +20,16 @@ def echo_post_json(request):
     except:
         return Response("パラメタのパースに失敗しました。")
 
+@api_view(["POST"])
+def create_tweet(request):
+    try:
+        json_data = json.loads(request.body)
+        twitter_tool_user_id = json_data["twitter-tool-user-id"]
+        twitter_username = json_data["twitter-username"]
+        text = json_data["text"]
+    except Exception as e:
+        return Response("Jsonのパースに失敗しました。")
+    db_handler = DbHandler()
+    consumer_key, consumer_secret, access_token, access_token_secret = db_handler.get_keys(twitter_tool_user_id, twitter_username)
+    twitter_api_v2_handler = TwitterApiV2Hander(consumer_key, consumer_secret, access_token, access_token_secret)
+    twitter_api_v2_handler.create_tweet(text)

--- a/backend/twitter_tool/views.py
+++ b/backend/twitter_tool/views.py
@@ -4,6 +4,7 @@ from twitter_tool.twitter_api_v2_handler import TwitterApiV2Handler
 from twitter_tool.db_handler import DbHandler
 import json
 
+
 @api_view(["GET"])
 def ping(request):
     return Response("OK")
@@ -19,6 +20,7 @@ def echo_post_json(request):
         })
     except:
         return Response("パラメタのパースに失敗しました。")
+
 
 @api_view(["POST"])
 def create_tweet(request):

--- a/backend/twitter_tool/views.py
+++ b/backend/twitter_tool/views.py
@@ -1,6 +1,6 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
-from twitter_tool.twitter_api_v2_handler import TwitterApiV2Hander
+from twitter_tool.twitter_api_v2_handler import TwitterApiV2Handler
 from twitter_tool.db_handler import DbHandler
 import json
 
@@ -27,9 +27,22 @@ def create_tweet(request):
         twitter_tool_user_id = json_data["twitter-tool-user-id"]
         twitter_username = json_data["twitter-username"]
         text = json_data["text"]
-    except Exception as e:
+    except:
         return Response("Jsonのパースに失敗しました。")
-    db_handler = DbHandler()
-    consumer_key, consumer_secret, access_token, access_token_secret = db_handler.get_keys(twitter_tool_user_id, twitter_username)
-    twitter_api_v2_handler = TwitterApiV2Hander(consumer_key, consumer_secret, access_token, access_token_secret)
-    twitter_api_v2_handler.create_tweet(text)
+
+    try:
+        db_handler = DbHandler()
+        consumer_key, consumer_secret, access_token, access_token_secret = db_handler.get_keys(twitter_tool_user_id, twitter_username)
+    except:
+        return Response("キー情報の取得に失敗しました。")
+
+    if access_token == "" or access_token_secret == "":
+        return Response(f"twitter-tool-user-id={twitter_tool_user_id}, twitter-user-name={twitter_username}のユーザが存在しません。")
+
+    try:
+        twitter_api_v2_handler = TwitterApiV2Handler(consumer_key, consumer_secret, access_token, access_token_secret)
+        response_str = twitter_api_v2_handler.create_tweet(text)
+        return Response(response_str)
+    except:
+        return Response("ツイートの投稿に失敗しました。")
+


### PR DESCRIPTION
### 概要
* ツイートするための口を追加( `/tweets/create` )
* まだこれらのことはできず、単に送信された文言をツイートするだけ
  * 画像のアップロード
  * エラーハンドリング
  * 不正な入力への対処
  * ユーザの切り替え（現状、devjimaのキー情報をバックエンドの環境変数に埋め込んでいる）
* 仕様書とかはもう少し機能がいろいろ整備できたら追加する予定
